### PR TITLE
处理码点大于U+010000的字符的length属性bug

### DIFF
--- a/src/rule/range.js
+++ b/src/rule/range.js
@@ -15,6 +15,8 @@ function range(rule, value, source, errors, options) {
   const len = typeof rule.len === 'number';
   const min = typeof rule.min === 'number';
   const max = typeof rule.max === 'number';
+  // 正则匹配码点范围从U+010000一直到U+10FFFF的文字（补充平面Supplementary Plane）
+  const spRegexp = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
   let val = value;
   let key = null;
   const num = typeof (value) === 'number';
@@ -33,8 +35,12 @@ function range(rule, value, source, errors, options) {
   if (!key) {
     return false;
   }
-  if (str || arr) {
+  if (arr) {
     val = value.length;
+  }
+  if (str) {
+    // 处理码点大于U+010000的文字length属性不准确的bug，如"𠮷𠮷𠮷".lenght !== 3
+    val = value.replace(spRegexp,'_').length;
   }
   if (len) {
     if (val !== rule.len) {


### PR DESCRIPTION
处理直接使用 String.prototype.length 对码点大于U+010000的字符不正确的问题。
"aaaa".lenght === 3
"𠮷𠮷𠮷".lenght !== 3